### PR TITLE
Do not download non-local binaries

### DIFF
--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -28,7 +28,7 @@ def _match_os(rctx, os):
     # rctx.os.name takes valeus from Java system property `os.name`
     if os == "macos" and rctx.os.name.startswith("mac"):
         return True
-    if os == "linux" and rctx.os.name == "linux":
+    if os == "linux" and rctx.os.name.lower() == "linux":
         return True
     return False
 

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -25,7 +25,7 @@ def _check(condition, message):
         fail(message)
 
 def _match_os(rctx, os):
-    # rctx.os.name takes valeus from Java system property `os.name`
+    # rctx.os.name takes values from Java system property `os.name`
     if os == "macos" and rctx.os.name.startswith("mac"):
         return True
     if os == "linux" and rctx.os.name.lower() == "linux":
@@ -33,7 +33,7 @@ def _match_os(rctx, os):
     return False
 
 def _match_cpu(rctx, cpu):
-    # rctx.os.arch takes valeus from Java system property `os.arch`
+    # rctx.os.arch takes values from Java system property `os.arch`
     if cpu == "x86_64" and rctx.os.arch == "x86_64":
         return True
     if cpu == "arm64" and rctx.os.arch == "aarch64":

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -30,7 +30,6 @@ def _match_os(rctx, os):
         return True
     if os == "linux" and rctx.os.name.lower() == "linux":
         return True
-    print("Unknown OS " + rctx.os.name)
     return False
 
 def _match_cpu(rctx, cpu):
@@ -39,7 +38,6 @@ def _match_cpu(rctx, cpu):
         return True
     if cpu == "arm64" and rctx.os.arch == "aarch64":
         return True
-    print("Unknown CPU " + rctx.os.arch)
     return False
 
 def _match_local(rctx, os, cpu):

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -30,7 +30,7 @@ def _match_os(rctx, os):
         return True
     if os == "linux" and rctx.os.name == "Linux":
         return True
-    print("Unknown OS " + os)
+    print("Unknown OS " + rctx.os.name)
     return False
 
 def _match_cpu(rctx, cpu):
@@ -39,7 +39,7 @@ def _match_cpu(rctx, cpu):
         return True
     if cpu == "arm64" and rctx.os.arch == "aarch64":
         return True
-    print("Unknown CPU " + cpu)
+    print("Unknown CPU " + rctx.os.arch)
     return False
 
 def _match_local(rctx, os, cpu):

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -28,7 +28,7 @@ def _match_os(rctx, os):
     # rctx.os.name takes values from Java system property `os.name`
     if os == "macos" and rctx.os.name.startswith("mac"):
         return True
-    if os == "linux" and rctx.os.name == "Linux":
+    if os == "linux" and rctx.os.name.lower() == "linux":
         return True
     print("Unknown OS " + rctx.os.name)
     return False

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -28,13 +28,13 @@ def _match_os(rctx, os):
     # rctx.os.name takes values from Java system property `os.name`
     if os == "macos" and rctx.os.name.startswith("mac"):
         return True
-    if os == "linux" and rctx.os.name.lower() == "linux":
+    if os == "linux" and rctx.os.name == "Linux":
         return True
     return False
 
 def _match_cpu(rctx, cpu):
     # rctx.os.arch takes values from Java system property `os.arch`
-    if cpu == "x86_64" and rctx.os.arch == "x86_64":
+    if cpu == "x86_64" and rctx.os.arch in ["x86_64", "amd64"]:
         return True
     if cpu == "arm64" and rctx.os.arch == "aarch64":
         return True

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -30,6 +30,7 @@ def _match_os(rctx, os):
         return True
     if os == "linux" and rctx.os.name == "Linux":
         return True
+    print("Unknown OS " + os)
     return False
 
 def _match_cpu(rctx, cpu):
@@ -38,6 +39,7 @@ def _match_cpu(rctx, cpu):
         return True
     if cpu == "arm64" and rctx.os.arch == "aarch64":
         return True
+    print("Unknown CPU " + cpu)
     return False
 
 def _match_local(rctx, os, cpu):


### PR DESCRIPTION
Today, we download all the declared binaries in our lockfile. This can be slow/expensive.

After this PR, we skip downloading any binary that doesn't match the local machine's OS or CPU. We're not users of remote execution, and it's not clear if/how this affects remote execution. If it negatively affects RBE, we can always drop this functionality behind a flag on our repository rules.
