### PR TITLE
add an extra_download_args field to pass extra args to the download functions

### DIFF
--- a/lockfile.schema.json
+++ b/lockfile.schema.json
@@ -31,6 +31,10 @@
                         },
                         "cpu": {
                             "enum": ["x86_64", "arm64"]
+                        },
+                        "extra_download_args": {
+                            "type": "object",
+                            "description": "additional arguments, such as 'headers' or 'type', passed to Bazel's download function"
                         }
                     },
                     "additionalProperties": false

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -110,6 +110,7 @@ def _env_specific_tools_impl(rctx):
                     sha256 = binary["sha256"],
                     output = target_executable,
                     executable = True,
+                    **binary.get("extra_download_args", {})
                 )
             elif binary["kind"] == "archive":
                 archive_path = "tools/{tool_name}/{os}_{cpu}_archive".format(
@@ -122,6 +123,7 @@ def _env_specific_tools_impl(rctx):
                     url = binary["url"],
                     sha256 = binary["sha256"],
                     output = archive_path,
+                    **binary.get("extra_download_args", {})
                 )
 
                 # link to the executable
@@ -147,6 +149,7 @@ def _env_specific_tools_impl(rctx):
                     url = binary["url"],
                     sha256 = binary["sha256"],
                     output = archive_path + ".pkg",
+                    **binary.get("extra_download_args", {})
                 )
 
                 rctx.execute([pkgutil_cmd, "--expand-full", archive_path + ".pkg", archive_path])


### PR DESCRIPTION
Adds an `extra_download_args` field to pass arbitrary args to the underlying download functions.

This makes it possible to download a wider variety of artifacts. For example, here's a manifest to download [`nickel`](https://nickel-lang.org/) from Homebrew's binary cache:

```
{
  "nickel": {
    "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
    "__version": "1.5.0",
    "binaries": [
      {
        "kind": "archive",
        "os": "macos",
        "cpu": "x86_64",
        "url": "https://ghcr.io/v2/homebrew/core/nickel/blobs/sha256:d59d317f7d3602c9350d48ee825119e68faeaeb534a7fdc3063c187d3355a5d0",
        "file": "nickel/1.5.0/bin/nickel",
        "sha256": "d59d317f7d3602c9350d48ee825119e68faeaeb534a7fdc3063c187d3355a5d0",
        "extra_download_args": {
          "headers": {
            "Authorization": "Bearer QQ=="
          },
          "type": "tar.gz"
        }
      },
      {
        "kind": "archive",
        "os": "macos",
        "cpu": "arm64",
        "url": "https://ghcr.io/v2/homebrew/core/nickel/blobs/sha256:adfbdbc42f9fb5aefd181ea0a798e224a64bb71a46cba200a07a9ae87a744cba",
        "file": "nickel/1.5.0/bin/nickel",
        "sha256": "adfbdbc42f9fb5aefd181ea0a798e224a64bb71a46cba200a07a9ae87a744cba",
        "extra_download_args": {
          "headers": {
            "Authorization": "Bearer QQ=="
          },
          "type": "tar.gz"
        }
      },
      {
        "kind": "archive",
        "os": "linux",
        "cpu": "x86_64",
        "url": "https://ghcr.io/v2/homebrew/core/nickel/blobs/sha256:5ff7a7f4adbbb072d382de788b365d1c902b5eef093a7222ff386c89cc6bb296",
        "file": "nickel/1.5.0/bin/nickel",
        "sha256": "5ff7a7f4adbbb072d382de788b365d1c902b5eef093a7222ff386c89cc6bb296",
        "extra_download_args": {
          "headers": {
            "Authorization": "Bearer QQ=="
          },
          "type": "tar.gz"
        }
      }
    ]
  }
}
```