### PR TITLE
Fix release automation script

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -49,7 +49,7 @@ http_archive(
     name = "rules_multitool",
     sha256 = "${SHA}",
     strip_prefix = "rules_multitool-${TAG:1}",
-    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v${TAG:1}/bazel_features-${TAG:1}.tar.gz",
+    url = "https://github.com/theoremlp/rules_multitool/releases/download/v${TAG:1}/rules_multitool-${TAG:1}.tar.gz",
 )
 
 load("@bazel_features//:deps.bzl", "bazel_features_deps")


### PR DESCRIPTION
I had the incorrect URL in our release automation script leading to erroneous release notes in 0.6.0. I've manually corrected the release notes for 0.6.0, this change will ensure future releases provide correct instructions.