### PR TITLE
Use exec to run cwd target

### DIFF
--- a/multitool/private/cwd.template.sh
+++ b/multitool/private/cwd.template.sh
@@ -3,6 +3,4 @@
 tool="{{tool}}"
 execdir="$PWD"
 
-pushd "$BUILD_WORKING_DIRECTORY" > /dev/null
-"$execdir/$tool" "$@"
-popd > /dev/null
+cd "$BUILD_WORKING_DIRECTORY" && exec "$execdir/$tool" "$@"

--- a/multitool/private/cwd.template.sh
+++ b/multitool/private/cwd.template.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 
-tool="{{tool}}"
-execdir="$PWD"
-
-cd "$BUILD_WORKING_DIRECTORY" && exec "$execdir/$tool" "$@"
+tool="$PWD/{{tool}}"
+cd "$BUILD_WORKING_DIRECTORY" && exec "$tool" "$@"


### PR DESCRIPTION
Feedback on #29 -- use exec in place of running the tool directly to keep the process tree clean.