### PR TITLE
Disable renovating Bazel dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
     ],
     "packageRules": [
       {
-        "matchFiles": ["MODULE.bazel"],
+        "matchFileNames": ["**/MODULE.bazel", "**/.bazelversion"],
         "enabled": false
       }
     ]


### PR DESCRIPTION
We fixed our organization-wide renovate setup but now we're starting to renovate Bazel deps in this ruleset. Rulesets, unlike other repositories, should want to preserve oldest possible versions. To that end, disable renovating Bazel files in this repo.