### PR TITLE
Handle lockfile merge with starlark idiosyncrasies

### DIFF
--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -65,7 +65,11 @@ def _load_tools(rctx):
         #  fix toolchains to also declare their versions and enable consumers
         #  to use constraints to pick the right one.
         #  (this is also a very naive merge at the tool level)
-        tools = tools | json.decode(rctx.read(lockfile))
+
+        # Read and merge dictionaries with RHS keys taking precedence.
+        # Using `tools | rhs_dict` would prefer LHS keys over RHS keys.
+        lock_dict = json.decode(rctx.read(lockfile))
+        tools.update(lock_dict)
 
     # a special key says this JSON document conforms to a schema
     tools.pop("$schema", None)


### PR DESCRIPTION
In Starlark, when you merge dictionaries using the | operator, the keys from the left-hand side (LHS) dictionary take precedence over the keys from the right-hand side (RHS) dictionary. This behavior might not be what you expect if you want the RHS keys to override the LHS keys.

In this approach, tools.update(lock_dict) will update the tools dictionary with the key-value pairs from lock_dict, and if any keys are already present in tools, their values will be overwritten by the corresponding values from lock_dict.