### PR TITLE
Fix lockfile registration to ensure root module lockfiles win conflicts

### DIFF
--- a/multitool/extension.bzl
+++ b/multitool/extension.bzl
@@ -10,7 +10,7 @@ hub = tag_class(
 
 def _extension(module_ctx):
     lockfiles = []
-    for mod in module_ctx.modules:
+    for mod in reversed(module_ctx.modules):
         for h in mod.tags.hub:
             lockfiles.append(h.lockfile)
 


### PR DESCRIPTION
## Issue
Fixes #41.

#41 highlighted that my assumption that a root module lockfile would override lockfiles coming from module dependencies. The iteration order of `module_ctx.modules` is [well specified](https://bazel.build/rules/lib/builtins/module_ctx#modules) and opposite of what I had assumed when originally writing this code.

## Summary
Reverse the iteration order of `module_ctx.modules` to ensure that root module declared tools win over module dependency declared tools.