### PR TITLE
Use netrc when configured for download auth

### DIFF
--- a/lockfile.schema.json
+++ b/lockfile.schema.json
@@ -23,6 +23,13 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "auth_patterns": {
+          "type": "object",
+          "docs": "See https://bazel.build/rules/lib/repo/http#http_archive-auth_patterns",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "required": ["kind", "url", "os", "cpu"]
@@ -64,6 +71,13 @@
             ".ar",
             ".deb"
           ]
+        },
+        "auth_patterns": {
+          "type": "object",
+          "docs": "See https://bazel.build/rules/lib/repo/http#http_archive-auth_patterns",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "required": ["kind", "url", "os", "cpu", "file"]
@@ -83,6 +97,13 @@
         "headers": {
           "type": "object",
           "docs": "headers to pass to the downloader (supported on Bazel >= 7.1.0)",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "auth_patterns": {
+          "type": "object",
+          "docs": "See https://bazel.build/rules/lib/repo/http#http_archive-auth_patterns",
           "additionalProperties": {
             "type": "string"
           }

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -71,13 +71,13 @@ def _check_version(os, binary_os):
         else:
             fail("rules_multitool: windows platform requires bazel 7.1+ to read artifacts; current bazel is " + native.bazel_version)
 
-def _get_auth(ctx, urls):
+def _get_auth(rctx, urls):
     "Returns an auth dict for the provided list or URLs."
-    if "NETRC" in ctx.os.environ:
-        netrc = read_netrc(ctx, ctx.os.environ["NETRC"])
+    if "NETRC" in rctx.os.environ:
+        netrc = read_netrc(rctx, rctx.os.environ["NETRC"])
     else:
-        netrc = read_user_netrc(ctx)
-    return use_netrc(netrc, urls, ctx.attr.auth_patterns)
+        netrc = read_user_netrc(rctx)
+    return use_netrc(netrc, urls, rctx.attr.auth_patterns)
 
 def _load_tools(rctx):
     tools = {}
@@ -148,7 +148,7 @@ def _env_specific_tools_impl(rctx):
                     sha256 = binary["sha256"],
                     output = target_executable,
                     executable = True,
-                    auth = _get_auth(ctx, [binary["url"]]),
+                    auth = _get_auth(rctx, [binary["url"]]),
                     **_feature_sensitive_args(binary)
                 )
             elif binary["kind"] == "archive":
@@ -196,7 +196,7 @@ def _env_specific_tools_impl(rctx):
                     url = binary["url"],
                     sha256 = binary["sha256"],
                     output = archive_path + ".pkg",
-                    auth = _get_auth(ctx, [binary["url"]]),
+                    auth = _get_auth(rctx, [binary["url"]]),
                     **_feature_sensitive_args(binary)
                 )
 

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -226,6 +226,7 @@ _env_specific_tools = repository_rule(
         "lockfiles": attr.label_list(mandatory = True, allow_files = True),
         "os": attr.string(),
         "cpu": attr.string(),
+        "auth_patterns": attr.string_dict(),
     },
     implementation = _env_specific_tools_impl,
 )

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -148,7 +148,7 @@ def _env_specific_tools_impl(rctx):
                     sha256 = binary["sha256"],
                     output = target_executable,
                     executable = True,
-                    auth = _get_auth(rctx, [binary["url"]], binary["auth_patterns"]),
+                    auth = _get_auth(rctx, [binary["url"]], binary.get("auth_patterns", {})),
                     **_feature_sensitive_args(binary)
                 )
             elif binary["kind"] == "archive":
@@ -163,7 +163,7 @@ def _env_specific_tools_impl(rctx):
                     sha256 = binary["sha256"],
                     output = archive_path,
                     type = binary.get("type", ""),
-                    auth = _get_auth(rctx, [binary["url"]], binary["auth_patterns"]),
+                    auth = _get_auth(rctx, [binary["url"]], binary.get("auth_patterns", {})),
                     **_feature_sensitive_args(binary)
                 )
 
@@ -196,7 +196,7 @@ def _env_specific_tools_impl(rctx):
                     url = binary["url"],
                     sha256 = binary["sha256"],
                     output = archive_path + ".pkg",
-                    auth = _get_auth(rctx, [binary["url"]], binary["auth_patterns"]),
+                    auth = _get_auth(rctx, [binary["url"]], binary.get("auth_patterns", {})),
                     **_feature_sensitive_args(binary)
                 )
 

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -72,7 +72,7 @@ def _check_version(os, binary_os):
             fail("rules_multitool: windows platform requires bazel 7.1+ to read artifacts; current bazel is " + native.bazel_version)
 
 def _get_auth(rctx, urls, auth_patterns):
-    "Returns an auth dict for the provided list or URLs."
+    "Returns an auth dict for the provided list of URLs."
     if "NETRC" in rctx.os.environ:
         netrc = read_netrc(rctx, rctx.os.environ["NETRC"])
     else:

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -163,7 +163,7 @@ def _env_specific_tools_impl(rctx):
                     sha256 = binary["sha256"],
                     output = archive_path,
                     type = binary.get("type", ""),
-                    auth = _get_auth(ctx, [binary["url"]]),
+                    auth = _get_auth(rctx, [binary["url"]]),
                     **_feature_sensitive_args(binary)
                 )
 

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -71,13 +71,13 @@ def _check_version(os, binary_os):
         else:
             fail("rules_multitool: windows platform requires bazel 7.1+ to read artifacts; current bazel is " + native.bazel_version)
 
-def _get_auth(rctx, urls):
+def _get_auth(rctx, urls, auth_patterns):
     "Returns an auth dict for the provided list or URLs."
     if "NETRC" in rctx.os.environ:
         netrc = read_netrc(rctx, rctx.os.environ["NETRC"])
     else:
         netrc = read_user_netrc(rctx)
-    return use_netrc(netrc, urls, rctx.attr.auth_patterns)
+    return use_netrc(netrc, urls, auth_patterns)
 
 def _load_tools(rctx):
     tools = {}
@@ -148,7 +148,7 @@ def _env_specific_tools_impl(rctx):
                     sha256 = binary["sha256"],
                     output = target_executable,
                     executable = True,
-                    auth = _get_auth(rctx, [binary["url"]]),
+                    auth = _get_auth(rctx, [binary["url"]], binary["auth_patterns"]),
                     **_feature_sensitive_args(binary)
                 )
             elif binary["kind"] == "archive":
@@ -163,7 +163,7 @@ def _env_specific_tools_impl(rctx):
                     sha256 = binary["sha256"],
                     output = archive_path,
                     type = binary.get("type", ""),
-                    auth = _get_auth(rctx, [binary["url"]]),
+                    auth = _get_auth(rctx, [binary["url"]], binary["auth_patterns"]),
                     **_feature_sensitive_args(binary)
                 )
 
@@ -196,7 +196,7 @@ def _env_specific_tools_impl(rctx):
                     url = binary["url"],
                     sha256 = binary["sha256"],
                     output = archive_path + ".pkg",
-                    auth = _get_auth(rctx, [binary["url"]]),
+                    auth = _get_auth(rctx, [binary["url"]], binary["auth_patterns"]),
                     **_feature_sensitive_args(binary)
                 )
 
@@ -226,7 +226,6 @@ _env_specific_tools = repository_rule(
         "lockfiles": attr.label_list(mandatory = True, allow_files = True),
         "os": attr.string(),
         "cpu": attr.string(),
-        "auth_patterns": attr.string_dict(),
     },
     implementation = _env_specific_tools_impl,
 )

--- a/readme.md
+++ b/readme.md
@@ -30,16 +30,23 @@ The lockfile supports the following binary kinds:
 - **file**: the URL refers to a file to download
 
   - `sha256`: the sha256 of the downloaded file
+  - `headers`: (optional) a string dictionary of headers to pass to the downloader
+  - `auth_patterns`: (optional) a string dictionary for use with .netrc files as in https://bazel.build/rules/lib/repo/http#http_file-auth_patterns
 
 - **archive**: the URL referes to an archive to download, specify additional options:
 
   - `file`: executable file within the archive
   - `sha256`: the sha256 of the downloaded archive
+  - `type`: (optional) the kind of archive, as in https://bazel.build/rules/lib/repo/http#http_archive-type
+  - `headers`: (optional) a string dictionary of headers to pass to the downloader
+  - `auth_patterns`: (optional) a string dictionary for use with .netrc files as in https://bazel.build/rules/lib/repo/http#http_archive-auth_patterns
 
 - **pkg**: the URL refers to a MacOS pkg archive to download, specify additional options:
 
   - `file`: executable file within the archive
   - `sha256`: the sha256 of the downloaded pkg archive
+  - `headers`: (optional) a string dictionary of headers to pass to the downloader
+  - `auth_patterns`: (optional) a string dictionary for use with .netrc files as in https://bazel.build/rules/lib/repo/http#http_archive-auth_patterns
 
 ### Bazel Module Usage
 


### PR DESCRIPTION
We received a request in Bazel Slack to support netrc-based authentication for downloads. This PR adds support based on the guidelines in https://www.stevenengelhardt.com/2023/03/02/practical-bazel-retrieving-secrets-from-netrc-in-custom-rules/.