### PR TITLE
chore: repro issue with fetching unrequested tool

### DIFF
--- a/examples/workspace/minimal_download_test.sh
+++ b/examples/workspace/minimal_download_test.sh
@@ -21,6 +21,7 @@ for file in target-determinator.darwin.arm64 target-determinator.linux.amd64 tar
   if [ "$file" != "$ALLOWED" ]; then
     cat >$DL_CONFIG <<EOF
 rewrite github.com/bazel-contrib/target-determinator/releases/download/([^/]+)/$file disallowed.build/\$1/$file
+rewrite github.com/google/go-jsonnet/releases/download/(.*) disallowed.build/\$1
 EOF
   fi
 done

--- a/examples/workspace/multitool.lock.json
+++ b/examples/workspace/multitool.lock.json
@@ -31,5 +31,41 @@
             "cpu": "x86_64"
           }
       ]
+  },
+  "jsonnetfmt": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Linux_arm64.tar.gz",
+        "file": "jsonnetfmt",
+        "sha256": "49fbc99c91dcd2be53fa856307de3b8708c91dc5c74740714fdf9317957322e0",
+        "os": "linux",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Linux_x86_64.tar.gz",
+        "file": "jsonnetfmt",
+        "sha256": "a137c5e969609c3995c4d05817a247cfef8a92760c5306c3ad7df0355dd62970",
+        "os": "linux",
+        "cpu": "x86_64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Darwin_arm64.tar.gz",
+        "file": "jsonnetfmt",
+        "sha256": "a15a699a58eb172c6d91f4cbddf3681095a649008628e0cfd84f564db4244ee3",
+        "os": "macos",
+        "cpu": "arm64"
+      },
+      {
+        "kind": "archive",
+        "url": "https://github.com/google/go-jsonnet/releases/download/v0.20.0/go-jsonnet_0.20.0_Darwin_x86_64.tar.gz",
+        "file": "jsonnetfmt",
+        "sha256": "76901637f60589bb9bf91b3481d4aecbc31efcd35ca99ae72bcb510b00270ad9",
+        "os": "macos",
+        "cpu": "x86_64"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Only the target-determinator tool is referenced by the build targets. So the added and unused entry in the multitool lock file should not be fetched.