### PR TITLE
Support multiple multitool hubs

### DIFF
--- a/examples/module/MODULE.bazel
+++ b/examples/module/MODULE.bazel
@@ -15,4 +15,13 @@ local_path_override(
 
 multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
 multitool.hub(lockfile = "//:multitool.lock.json")
-use_repo(multitool, "multitool")
+
+# example of an alternate named hub
+multitool.hub(
+    name = "alt",
+    lockfile = "//:multitool.lock.json",
+)
+use_repo(multitool, "alt", "multitool")
+
+# required to use alternate hub's tools
+register_toolchains("@alt//toolchains:all")

--- a/examples/module/MODULE.bazel
+++ b/examples/module/MODULE.bazel
@@ -18,7 +18,7 @@ multitool.hub(lockfile = "//:multitool.lock.json")
 
 # example of an alternate named hub
 multitool.hub(
-    name = "alt",
+    hub_name = "alt",
     lockfile = "//:multitool.lock.json",
 )
 use_repo(multitool, "alt", "multitool")

--- a/multitool/extension.bzl
+++ b/multitool/extension.bzl
@@ -2,16 +2,18 @@
 
 load("//multitool/private:multitool.bzl", _hub = "bzlmod_hub")
 
+_DEFAULT_HUB_NAME = "multitool"
+
 hub = tag_class(
     attrs = {
-        "hub_name": attr.string(default = "multitool"),
+        "hub_name": attr.string(default = _DEFAULT_HUB_NAME),
         "lockfile": attr.label(mandatory = True, allow_single_file = True),
     },
 )
 
 def _extension(module_ctx):
     lockfiles = {
-        "multitool": [],
+        _DEFAULT_HUB_NAME: [],
     }
     for mod in reversed(module_ctx.modules):
         for h in mod.tags.hub:

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,22 @@ use_repo(multitool, "multitool")
 
 Tools may then be accessed using `@multitool//tools/tool-name`.
 
+It's safe to call `multitool.hub(...)` multiple times, with multiple lockfiles. All lockfiles will be combined with a last-write-wins strategy.
+
+Lockfiles defined across modules and applying to the same hub (including implicitly to the default "multitool" hub) will be combined such that the priority follows a breadth-first search originatiung from the root module.
+
+It's possible to define multiple multitool hubs to group related tools together. To define an alternate hub:
+
+```python
+multitool.hub(hub_name = "alt_hub", lockfile = "//:other_tools.lock.json")
+use_repo(multitool, "alt_hub")
+
+# register the tools from this hub
+register_toolchains("@alt_hub//toolchains:all")
+```
+
+These alternate hubs also combine lockfiles according to the hub_name and follow the same merging rules as the default hub.
+
 ### Workspace Usage
 
 Instructions for using with WORKSPACE may be found in [release notes](https://github.com/theoremlp/rules_multitool/releases).
@@ -89,3 +105,9 @@ A common pattern we recommend to further simplify invoking tools for repository 
 We provide a companion CLI [multitool](https://github.com/theoremlp/multitool) to help manage multitool lockfiles. The CLI supports basic updating of artifacts that come from GitHub releases, and may be extended in the future to support other common release channels.
 
 See [our docs](docs/automation.md) on configuring a GitHub Action to check for updates and open PRs periodically.
+
+### Using Multiple Hubs
+
+rules_multitool 0.16.0+ supports registering multiple multitool hubs.
+
+#### Multiple Hubs when using as a Bazel Module

--- a/readme.md
+++ b/readme.md
@@ -105,9 +105,3 @@ A common pattern we recommend to further simplify invoking tools for repository 
 We provide a companion CLI [multitool](https://github.com/theoremlp/multitool) to help manage multitool lockfiles. The CLI supports basic updating of artifacts that come from GitHub releases, and may be extended in the future to support other common release channels.
 
 See [our docs](docs/automation.md) on configuring a GitHub Action to check for updates and open PRs periodically.
-
-### Using Multiple Hubs
-
-rules_multitool 0.16.0+ supports registering multiple multitool hubs.
-
-#### Multiple Hubs when using as a Bazel Module


### PR DESCRIPTION
We've supported multiple hubs in WORKSPACE for a while, but bzlmod users were forced to constrain to a single common hub.

This PR maintains existing behavior but treats the common `multitool` hub as the default hub, still registers its toolchains, and now offers the ability to register additional, alternate hubs by name under the same combination rules. It also updates the readme to share how to do this in bzlmod, and calls out that users must invoke `register_toolchains` themselves in order to make the alternate hubs' tools available to Bazel.
