### PR TITLE
Export a list of all tools in a hub as a Starlark constant

### DIFF
--- a/multitool/private/hub_repo_template/tools.bzl.template
+++ b/multitool/private/hub_repo_template/tools.bzl.template
@@ -1,4 +1,8 @@
 load("@rules_multitool//multitool/private:multitool.bzl", "tool_repo")
 
+TOOLS = {
+{tool_labels}
+}
+
 def register_tools():
 {tool_repos}

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -208,8 +208,8 @@ def _multitool_hub_impl(rctx):
         "{defines}": "\n".join(defines),
     })
 
-    # workspace compat
-    templates.hub(rctx, "tools.bzl", templates.workspace_substitutions(rctx.attr.name, tools))
+    # workspace compat & list of all tools
+    templates.hub(rctx, "tools.bzl", templates.tools_substitutions(rctx.attr.name, tools))
 
 _multitool_hub = repository_rule(
     attrs = {

--- a/multitool/private/templates.bzl
+++ b/multitool/private/templates.bzl
@@ -38,6 +38,12 @@ def _render_hub_tool(rctx, tool_name, filename, substitutions = None):
         } | (substitutions or {}),
     )
 
+def _renter_tool_labels(tools):
+    return "\n".join([
+        "    \"{tool_name}\": Label(\"//tools/{tool_name}\"),".format(tool_name = tool_name)
+        for tool_name in tools.keys()
+    ])
+
 def _render_tool_repo(hub_name, tool_name, binary):
     name = "{name}.{tool_name}.{os}_{cpu}".format(
         name = hub_name,
@@ -66,8 +72,9 @@ def _render_tool_repos(hub_name, tools):
         for binary in tool["binaries"]
     ])
 
-def _workspace_subs(hub_name, tools):
+def _tools_subs(hub_name, tools):
     return {
+        "{tool_labels}": _renter_tool_labels(tools),
         "{tool_repos}": _render_tool_repos(hub_name, tools),
     }
 
@@ -76,5 +83,5 @@ templates = struct(
     hub_tool = _render_hub_tool,
     tool = _render_tool,
     tool_tool = _render_tool_tool,
-    workspace_substitutions = _workspace_subs,
+    tools_substitutions = _tools_subs,
 )


### PR DESCRIPTION
This makes it easy to consume all available tools in other rules, such as `bazel_env.bzl`.

Strict visibility between modules using rules_multitool is preserved by requiring a `load` from the hub repo, which explicitly doesn't allow discovery of hub names.