### PR TITLE
Render TOOLS only if supported on host

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,10 +6,10 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "bazel_features", version = "1.9.0")
+bazel_dep(name = "bazel_features", version = "1.11.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
-bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "platforms", version = "0.0.10")
 
 # ensure toolchains get registered
 multitool = use_extension("//multitool:extension.bzl", "multitool")

--- a/examples/workspace/WORKSPACE.bazel
+++ b/examples/workspace/WORKSPACE.bazel
@@ -2,6 +2,25 @@ load("@bazel_features//:deps.bzl", "bazel_features_deps")
 
 bazel_features_deps()
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "platforms",
+    sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+        "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+    ],
+)
+
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+maybe(
+    host_platform_repo,
+    name = "host_platform",
+)
+
 load("@rules_multitool//multitool:multitool.bzl", "multitool")
 
 multitool(

--- a/multitool/private/multitool.bzl
+++ b/multitool/private/multitool.bzl
@@ -11,7 +11,7 @@ Multitool takes as input a JSON lockfile and emits the following repos:
          [tool-name]/
            BUILD.bazel            (export all *_executable files)
            [os]_[cpu]_executable  (a downloaded file or a symlink to a file in a
-                                   downloaded and extracted archive)    
+                                   downloaded and extracted archive)
 
  - [hub]:
      This repository holds toolchain definitions for all tools in the provided


### PR DESCRIPTION
Fixes https://github.com/theoremlp/rules_multitool/issues/79

The `TOOLS` constant was added to be used with bazel_env.bzl. For this we should only add tools that are supported on the host platform.