### PR TITLE
Use rules_shell starlark rules

### DIFF
--- a/examples/module/BUILD.bazel
+++ b/examples/module/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_multitool//multitool:cwd.bzl", "cwd")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//:add_dummy_file.bzl", "add_dummy_file")
 
 sh_test(

--- a/examples/module/MODULE.bazel
+++ b/examples/module/MODULE.bazel
@@ -6,7 +6,8 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_shell", version = "0.4.0")
 bazel_dep(name = "rules_multitool", version = "0.0.0")
 local_path_override(
     module_name = "rules_multitool",


### PR DESCRIPTION
In future versions of bazel, the native rules might result in an error when the respective rules' starlarkification is completed.