### PR TITLE
chore: fixes required for stardoc

### DIFF
--- a/multitool/BUILD.bazel
+++ b/multitool/BUILD.bazel
@@ -4,10 +4,12 @@ bzl_library(
     name = "extension",
     srcs = ["extension.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//multitool/private:multitool"],
 )
 
 bzl_library(
     name = "multitool",
     srcs = ["multitool.bzl"],
     visibility = ["//visibility:public"],
+    deps = ["//multitool/private:multitool"],
 )

--- a/multitool/multitool.bzl
+++ b/multitool/multitool.bzl
@@ -5,12 +5,12 @@ load("//multitool/private:multitool.bzl", "workspace_hub")
 def multitool(name, lockfile = None, lockfiles = None):
     """(non-bzlmod) Create a multitool hub and register its toolchains.
 
+    Note: exactly one of lockfile or lockfiles may be set.
+
     Args:
         name: resulting "hub" repo name to load tools from
         lockfile: a label for a lockfile, see /lockfile.schema.json
         lockfiles: a list of labels of multiple lockfiles
-
-    Note: exactly one of lockfile or lockfiles may be set.
     """
     if (not lockfile and not lockfiles) or (lockfile and lockfiles):
         fail("Exactly one of lockfile and lockfiles must be set")

--- a/multitool/private/BUILD.bazel
+++ b/multitool/private/BUILD.bazel
@@ -9,4 +9,22 @@ bzl_library(
     name = "multitool",
     srcs = ["multitool.bzl"],
     visibility = ["//multitool:__subpackages__"],
+    deps = [
+        ":lockfile",
+        ":templates",
+        "@bazel_features//:features",
+        "@bazel_tools//tools/build_defs/repo:utils.bzl",
+    ],
+)
+
+bzl_library(
+    name = "lockfile",
+    srcs = ["lockfile.bzl"],
+    visibility = ["//multitool:__subpackages__"],
+)
+
+bzl_library(
+    name = "templates",
+    srcs = ["templates.bzl"],
+    visibility = ["//multitool:__subpackages__"],
 )


### PR DESCRIPTION
I'm writing a stardoc extraction pipeline, and get errors because some bzl_library targets are incorrectly missing deps. This is because bzl_library has no validation actions, see https://github.com/bazelbuild/bazel-skylib/issues/568