### PR TITLE
fix: Add executable to runfiles of tools

### DIFF
--- a/multitool/private/hub_repo_tool_template/tool.bzl.template
+++ b/multitool/private/hub_repo_tool_template/tool.bzl.template
@@ -8,7 +8,10 @@ def _tool_impl(ctx):
     toolchain = ctx.toolchains[_TOOLCHAIN_TYPE]
     output = ctx.actions.declare_file(ctx.label.name + toolchain.ext)
     ctx.actions.symlink(output = output, target_file = toolchain.executable)
-    return [DefaultInfo(executable = output)]
+    return [DefaultInfo(
+      executable = output,
+      runfiles = ctx.runfiles(files = [toolchain.executable])
+    )]
 
 tool = rule(executable = True, implementation = _tool_impl, toolchains = [_TOOLCHAIN_TYPE])
 


### PR DESCRIPTION
Otherwise, depending on the tool target is usually not enough to use the tool as part of the Bazel build.

For instance: I'm trying to use `pkg-config` to compile the `alsa-sys` crate. I want to point the `PKG_CONFIG` env var to a `pkg-config` managed by `rules_multitool`, so I do it through an annotation:

```starlark
crate.annotation(
    build_script_env = {
        "PKG_CONFIG": "$(execpath @multitool//tools/pkg-config:pkg-config)",
    },
    build_script_tools = [ # Works really well with multitool, since it selects for the `exec` platform.
        "@multitool//tools/pkg-config:pkg-config",
    ],
    crate = "alsa-sys",
)
```

Before this change, only the symlink got materialized in the sandbox, so it (understandably) failed to run. Now, the symlink's target is also materialized.