### PR TITLE
Update bazel_lib version and add buildifier_prebuilt as dev_dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,11 +6,12 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "bazel_lib", version = "3.0.0-rc.0")
+bazel_dep(name = "bazel_lib", version = "3.0.0")
 bazel_dep(name = "bazel_features", version = "1.11.0")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 bazel_dep(name = "platforms", version = "0.0.10")
+
+bazel_dep(name = "buildifier_prebuilt", version = "7.3.1", dev_dependency = True)
 
 # ensure toolchains get registered
 multitool = use_extension("//multitool:extension.bzl", "multitool")


### PR DESCRIPTION
Found while working on https://github.com/bazelbuild/bazel/pull/27674#issuecomment-3710002496 in https://buildkite.com/bazel/bcr-bazel-compatibility-test/builds/723/steps/canvas?sid=019b8ddb-dbd2-4660-99eb-88a29fe339fe.