### PR TITLE
chore: remove 0.0.0 version

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -9,12 +9,7 @@ TAG="${GITHUB_REF_NAME}"
 PREFIX="rules_multitool-${TAG:1}"
 ARCHIVE="rules_multitool-${TAG:1}.tar.gz"
 
-# embed version in MODULE.bazel
-perl -pi -e "s/version = \"0\.0\.0\",/version = \"${TAG:1}\",/g" MODULE.bazel
-
-stash_name=`git stash create`;
-git archive --format=tar --prefix=${PREFIX}/ "${stash_name}" | gzip > $ARCHIVE
-
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 # Add generated API docs to the release, see https://github.com/bazelbuild/bazel-central-registry/issues/5593

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,6 @@
 
 module(
     name = "rules_multitool",
-    version = "0.0.0",
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
Downstreams https://github.com/bazel-contrib/rules-template/commit/fb992e13e2d205f34ce35496722340a25b11d4e8

Note the publish-to-bcr workflow will still patch the MODULE.bazel file in PRs to the BCR.