### PR TITLE
fix: use target_compatible_with only for toolchain declarations

### DIFF
--- a/multitool/private/hub_repo_template/toolchain_info.bzl.template
+++ b/multitool/private/hub_repo_template/toolchain_info.bzl.template
@@ -36,17 +36,7 @@ def declare_toolchain(name, os, cpu, toolchain_type):
     )
 
     native.toolchain(
-        name = "{name}_{os}_{cpu}_toolchain_exec".format(name=name, os=os, cpu=cpu),
-        toolchain = ":{name}_{os}_{cpu}_toolchain_info".format(name=name, os=os, cpu=cpu),
-        toolchain_type = toolchain_type,
-        exec_compatible_with = [
-            "@platforms//cpu:{cpu}".format(cpu=cpu),
-            "@platforms//os:{os}".format(os=os),
-        ],
-    )
-
-    native.toolchain(
-        name = "{name}_{os}_{cpu}_toolchain_target".format(name=name, os=os, cpu=cpu),
+        name = "{name}_{os}_{cpu}_toolchain".format(name=name, os=os, cpu=cpu),
         toolchain = ":{name}_{os}_{cpu}_toolchain_info".format(name=name, os=os, cpu=cpu),
         toolchain_type = toolchain_type,
         target_compatible_with = [


### PR DESCRIPTION
Per discussion in #104/#124:
- Remove mixed exec+target toolchain registrations
- Use `target_compatible_with` only on `toolchain()` declarations

When the tool is used as an artifact input (rules_oci / pkg_tar), `target_compatible_with` correctly matches the requested target platform.
When the tool is used as a build tool (`cfg="exec"`), Bazel sets `target_platform = exec_platform` in exec config, so `target_compatible_with` still matches the execution platform.

Using `exec_compatible_with` instead would break the artifact-input case: it would always pick the host architecture regardless of the requested `--platforms`, which is the original bug.

Fixes #104, Fixes #124